### PR TITLE
Better logging for expected revert error + detailed README(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ a walnut with a secret number inside.
 Every time you shake the walnut, this number increments. Every time you hit the
 walnut, the shell gets closer to cracking. You can only look at the number once
 the shell is cracked.
+
+### Local Development
+
+First, go through the [`contracts` README](packages/contracts/README.md) to set up the `Walnut` contract.
+
+Then, go through the [`cli` README](packages/cli/README.md) to set up and run the CLI.
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ the shell is cracked.
 
 ### Local Development
 
+#### Prerequisites
+Make sure you have the `seismic-foundry` suite of dev tools installed. See the installation instructions [here](https://docs.seismic.systems/onboarding/publish-your-docs).
+
+
 #### Installing dependencies
 Make sure you have [bun](https://bun.sh/docs/installation) installed.
 Install the dependencies for the project by running:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,20 @@ the shell is cracked.
 
 ### Local Development
 
-First, go through the [`contracts` README](packages/contracts/README.md) to set up the `Walnut` contract.
+#### Installing dependencies
+Make sure you have [bun](https://bun.sh/docs/installation) installed.
+Install the dependencies for the project by running:
 
-Then, go through the [`cli` README](packages/cli/README.md) to set up and run the CLI.
+```bash
+bun install
+```
+from the root directory.
+
+#### Setting up the contracts
+
+Go to the [`contracts` directory](packages/contracts/) and follow the instructions in the [`contracts` README](packages/contracts/README.md) to set up the `Walnut` contract.
+
+#### Setting up and running the CLI
+
+Then, go to the [`cli` directory](packages/cli/) and follow the instructions in the [`cli` README](packages/cli/README.md) to set up and run the CLI.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
-# Local Development Instructions
+# Local development instructions
 
-Firstly, make sure that you have followed the instructions in the [contracts README](../contracts/README.md) to properly set up the files required for the CLI to run.
+Firstly, make sure that you have followed the instructions in the [`contracts` README](../contracts/README.md) to properly set up the files required for the CLI to run.
 
 1. Set up and source your environment variables by copying the example `.env`file:
    ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,7 @@
 # Local Development Instructions
 
+Firstly, make sure that you have followed the instructions in the [contracts README](../contracts/README.md) to properly set up the files required for the CLI to run.
+
 1. Set up and source your environment variables by copying the example `.env`file:
    ```bash
    cp .env.example .env

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,12 @@
+# Local Development Instructions
+
+1. Set up and source your environment variables by copying the example `.env`file:
+   ```bash
+   cp .env.example .env
+   source .env
+   ```
+
+2. Start the CLI:
+   ```bash
+   bun dev
+   ```

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -74,12 +74,14 @@ async function main() {
   await app.look('Bob')
 
   // Alice tries to look in round 2, should fail by reverting
+  console.log('=== Testing Access Control ===')
+  console.log("Attempting Alice's look() in Bob's round (should revert)")
   try {
     await app.look('Alice')
+    console.error('❌ Expected look() to revert but it succeeded')
+    process.exit(1)
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    console.error('Alice could not call look() in round 2:', errorMessage)
+    console.log('✅ Received expected revert')
   }
 }
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -3,27 +3,27 @@
 1. Open up a new terminal and start `sanvil`.
 
 ```bash
-$ sanvil
+sanvil
 ```
 
 2. Set the environment variables. You can copy our example `.env` file to start.
 
 ```bash
-$ cd packages/contracts/
-$ cp .env.example .env
+cd packages/contracts/
+cp .env.example .env
 ```
 
 3. Ensure contract tests are passing. From this directory, run
 ```bash
-$ sforge build
-$ sforge test
+sforge build
+sforge test
 ```
 
 4. Deploy the contract.
 
 ```bash
-$ source .env
-$ sforge script script/Walnut.s.sol:WalnutScript \
+source .env
+sforge script script/Walnut.s.sol:WalnutScript \
       --rpc-url $RPC_URL \
       --broadcast
 ```


### PR DESCRIPTION
This PR introduces the following: 
1. Better logging in the `cli` for the case when Alice tries to look at the kernel in round 2 (where she isn't a contributor). We expect a revert here, hence catching an error should log that we have indeed received an error.
2. Detailed `README`s for the `cli`, `contracts` and additions to the root-level `README` which provides high level instructions and steps for the end to end local development flow.